### PR TITLE
update to launchy 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :production do
   gem "rake", "0.8.7"
   gem "thor", "0.14.6"
   gem "nokogiri", "1.4.4"
-  gem "launchy", "0.3.7"
+  gem "launchy", "2.0.3"
   gem "thin", "1.2.7"
   gem "sinatra", "1.1.2"
   gem "haml", "3.0.25"

--- a/lib/sonia/cli.rb
+++ b/lib/sonia/cli.rb
@@ -11,7 +11,7 @@ module Sonia
     def start
       require "sonia"
       Sonia::Server.run!(Config.new(options)) do
-        Launchy::Browser.run(Sonia::Server.webserver_url) unless options[:'no-auto']
+        Launchy.open(Sonia::Server.webserver_url) unless options[:'no-auto']
       end
     end
 


### PR DESCRIPTION
Hi, I've updated launchy, and the "Launchy::Browser" api is no deprecated. This pull request should update you to the new api. 

enjoy,

-jeremy
