### PR TITLE
Update gems to latest; remove monkeypatch for WebSocket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 group :production do
-  gem "activesupport", "3.2.3"
-  gem "twitter-stream", "0.1.14"
-  gem "eventmachine", "1.0.0.beta.4"
-  gem "em-websocket", "0.3.6"
-  gem "em-http-request", "1.0.2"
-  gem "yajl-ruby", "1.1.0"
-  gem "rake", "0.9.2.2"
+  gem "activesupport"
+  gem "twitter-stream"
+  gem "eventmachine"
+  gem "em-websocket"
+  gem "em-http-request"
+  gem "yajl-ruby"
+  gem "rake"
   gem "thor", "0.14.6"
-  gem "nokogiri", "1.5.2"
-  gem "launchy", "2.1.0"
-  gem "thin", "1.3.1"
-  gem "sinatra", "1.3.2"
-  gem "haml", "3.1.4"
+  gem "nokogiri"
+  gem "launchy"
+  gem "thin"
+  gem "sinatra"
+  gem "haml"
   gem "i18n"
   gem "roxml"
 end
@@ -28,5 +28,5 @@ group :development do
   #gem "ruby_core_source"
   gem "jeweler"
   gem "gemcutter"
-  #gem "ruby-debug19"
+  gem "debugger"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,95 +1,104 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    activesupport (3.2.3)
+    activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.2.7)
+    addressable (2.3.4)
+    columnize (0.3.6)
     cookiejar (0.3.0)
-    daemons (1.1.8)
-    diff-lcs (1.1.3)
-    em-http-request (1.0.2)
+    daemons (1.1.9)
+    debugger (1.6.0)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.2.1)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.2.2)
+    diff-lcs (1.2.3)
+    em-http-request (1.0.3)
       addressable (>= 2.2.3)
       cookiejar
       em-socksify
       eventmachine (>= 1.0.0.beta.4)
       http_parser.rb (>= 0.5.3)
-    em-socksify (0.2.0)
+    em-socksify (0.2.1)
       eventmachine (>= 1.0.0.beta.4)
-    em-websocket (0.3.6)
-      addressable (>= 2.1.1)
+    em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
-    eventmachine (1.0.0.beta.4)
+      http_parser.rb (~> 0.5.3)
+    eventmachine (1.0.3)
     gemcutter (0.7.1)
     git (1.2.5)
-    haml (3.1.4)
+    haml (4.0.2)
+      tilt
     http_parser.rb (0.5.3)
-    i18n (0.6.0)
-    jeweler (1.8.3)
+    i18n (0.6.4)
+    jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
       rdoc
-    json (1.6.6)
-    launchy (2.1.0)
-      addressable (~> 2.2.6)
-    multi_json (1.2.0)
-    nokogiri (1.5.2)
-    rack (1.4.1)
-    rack-protection (1.2.0)
+    json (1.7.7)
+    launchy (2.3.0)
+      addressable (~> 2.3)
+    multi_json (1.7.2)
+    nokogiri (1.5.9)
+    rack (1.5.2)
+    rack-protection (1.5.0)
       rack
-    rake (0.9.2.2)
-    rdoc (3.12)
+    rake (10.0.4)
+    rdoc (4.0.1)
       json (~> 1.4)
     roxml (3.3.1)
       activesupport (>= 2.3.0)
       nokogiri (>= 1.3.3)
-    rspec (2.9.0)
-      rspec-core (~> 2.9.0)
-      rspec-expectations (~> 2.9.0)
-      rspec-mocks (~> 2.9.0)
-    rspec-core (2.9.0)
-    rspec-expectations (2.9.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.9.0)
-    simple_oauth (0.1.5)
-    sinatra (1.3.2)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
-      tilt (~> 1.3, >= 1.3.3)
-    thin (1.3.1)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+    simple_oauth (0.1.9)
+    sinatra (1.4.2)
+      rack (~> 1.5, >= 1.5.2)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     thor (0.14.6)
-    tilt (1.3.3)
-    twitter-stream (0.1.14)
+    tilt (1.3.7)
+    twitter-stream (0.1.16)
       eventmachine (>= 0.12.8)
       http_parser.rb (~> 0.5.1)
       simple_oauth (~> 0.1.4)
     yajl-ruby (1.1.0)
-    yard (0.7.5)
+    yard (0.8.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 3.2.3)
-  em-http-request (= 1.0.2)
-  em-websocket (= 0.3.6)
-  eventmachine (= 1.0.0.beta.4)
+  activesupport
+  debugger
+  em-http-request
+  em-websocket
+  eventmachine
   gemcutter
-  haml (= 3.1.4)
+  haml
   i18n
   jeweler
-  launchy (= 2.1.0)
-  nokogiri (= 1.5.2)
-  rake (= 0.9.2.2)
+  launchy
+  nokogiri
+  rake
   roxml
   rspec
-  sinatra (= 1.3.2)
-  thin (= 1.3.1)
+  sinatra
+  thin
   thor (= 0.14.6)
-  twitter-stream (= 0.1.14)
-  yajl-ruby (= 1.1.0)
+  twitter-stream
+  yajl-ruby
   yard

--- a/lib/sonia/server.rb
+++ b/lib/sonia/server.rb
@@ -5,18 +5,6 @@ require "yajl"
 require "yaml"
 require "thin"
 
-# monkey patch pending fix
-module EventMachine
-  module WebSocket
-    class Connection < EventMachine::Connection
-      def send(data)
-        debug [:send, data]
-        send_data("\x00#{data.force_encoding(Encoding::ASCII_8BIT)}\xff")
-      end
-    end
-  end
-end
-
 module Sonia
   # Main Sonia event loop
   #


### PR DESCRIPTION
I was able to get sonia running with latest gems and removing the monkeypatch for WebSocket.
